### PR TITLE
Modified `vercel.json`.

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,7 @@
     ],
     "functions": {
         "api/app.py": {
-            "maxDuration": 600
+            "maxDuration": 60
         }
     }
 }


### PR DESCRIPTION
- Added `"maxDuration": 600` to `vercel.json` to fix the problem: `This Serverless Function has timed out.`.